### PR TITLE
fix: provide nice errors on failure

### DIFF
--- a/main.go
+++ b/main.go
@@ -137,7 +137,8 @@ func main() {
 
 	stacks, err := util.ParseStacks(r, linePrefix)
 	if err != nil {
-		panic(err)
+		fmt.Println(err)
+		os.Exit(1)
 	}
 
 	sorter := util.StackSorter{


### PR DESCRIPTION
1. Avoid panicing when parsing stacktraces. Instead, print an error (with a backtrace).
2. Always include a line number. This makes it much easier to debug errors.