### PR TITLE
feat: allow filtering by line number.

### DIFF
--- a/util/stack.go
+++ b/util/stack.go
@@ -55,7 +55,7 @@ type Filter func(s *Stack) bool
 func HasFrameMatching(pattern string) Filter {
 	return func(s *Stack) bool {
 		for _, f := range s.Frames {
-			if strings.Contains(f.Function, pattern) || strings.Contains(f.File, pattern) {
+			if strings.Contains(f.Function, pattern) || strings.Contains(fmt.Sprintf("%s:%d", f.File, f.Line), pattern) {
 				return true
 			}
 		}


### PR DESCRIPTION
This makes it easy to filter out all goroutines "stuck" at a particular line and is useful for debugging deadlocks and contention.